### PR TITLE
Add CLI version sub-command

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,9 +28,9 @@ jobs:
 
     - uses: prefix-dev/setup-pixi@v0.9.5
       with:
-        pixi-version: v0.63.2
+        pixi-version: v0.67.2
         cache: true
-        environments: cpu-py313
+        environments: cpu-py312 # Use Python 3.12 for documentation deployment as 3.13 needs to build dm-tree from source
 
     - name: Build and Deploy Documentation
       run: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 ## Improvements
 
+- Add CLI sub-command which shows version in [#54](https://github.com/cole-group/presto/pull/54).
 - Add Orb-v3 OMOL model in [#49](https://github.com/cole-group/presto/pull/49).
 
 ## 0.6.0

--- a/presto/_cli.py
+++ b/presto/_cli.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from pydantic_settings import CliApp, CliPositionalArg, CliSubCommand
 from rich.logging import RichHandler
 
+from . import __version__
 from .analyse import analyse_workflow
 from .outputs import OutputStage, OutputType, StageKind, WorkflowPathManager
 from .settings import (
@@ -29,10 +30,16 @@ def setup_logging_for_cli(log_level: str = "INFO") -> None:
     logger.remove()
     logger.add(
         RichHandler(show_time=True, markup=True),
-        # format="{level} | {message}",
         format="{message}",
         level=log_level.upper(),
     )
+
+
+class Version(BaseModel):
+    """Print the version of presto and exit."""
+
+    def cli_cmd(self) -> None:
+        print(f"presto {__version__}")
 
 
 class TrainFromCli(WorkflowSettings):
@@ -110,6 +117,10 @@ class Analyse(BaseModel):
 class CLI(BaseModel):
     """presto: parameterise a bespoke force field from high-temperature MD data."""
 
+    version: CliSubCommand[Version] = Field(
+        description="Print the version of presto and exit.",
+    )
+
     train: CliSubCommand[TrainFromCli] = Field(
         description="Train a bespoke force field from high-temperature MD data",
     )
@@ -139,7 +150,4 @@ class CLI(BaseModel):
 
 def run_cli() -> None:
     suppress_unwanted_output()
-
-    CliApp.run(
-        CLI,
-    )
+    CliApp.run(CLI)

--- a/presto/tests/unit/test__cli.py
+++ b/presto/tests/unit/test__cli.py
@@ -17,6 +17,8 @@ from presto.settings import (
     WorkflowSettings,
 )
 
+from ... import __version__
+
 
 class TestWriteDefaultYAML:
     """Tests for WriteDefaultYAML command."""
@@ -162,6 +164,16 @@ class TestAnalyse:
 
 class TestCLISubprocess:
     """Test the CLI via subprocess calls."""
+
+    def test_cli_version(self):
+        """Test that CLI --version prints the package version and exits cleanly."""
+        result = subprocess.run(
+            ["presto", "version"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert __version__ in result.stdout
 
     def test_cli_help(self):
         """Test that CLI help works."""


### PR DESCRIPTION
## Description

Add a CLI sub-command which prints the version (e.g. `presto version`).

This closes https://github.com/cole-group/presto/issues/51.

## Status
- [x] Ready to go
